### PR TITLE
add release note for v0.4.4 #PA-642

### DIFF
--- a/_sidebar.v002.md
+++ b/_sidebar.v002.md
@@ -11,3 +11,5 @@
   - [Pipeline](v002/guides/03-pipeline.md)
   - [Environemnt Configuration](v002/guides/04-environment-configuration.md)
   - [Deployment](v002/guides/05-deployment.md)
+- Release Notes
+  - [Versions](v002/release-notes/01-versions.md)

--- a/v002/release-notes/01-versions.md
+++ b/v002/release-notes/01-versions.md
@@ -1,0 +1,9 @@
+# Release Notes
+
+## [v0.4.4](https://github.com/podder-ai/podder-installer/releases/tag/0.4.4) (2019-05-31)
+
+### Implemented enhancements:
+- Display correct architecture for Linux when installing podder-cli.
+
+### Resolved bugs:
+- Fix test for installer service


### PR DESCRIPTION
PodderInstallerのリリースノートの情報を追加しました。
現状0.4.4のみReleasesが登録されていたため、リリースノートに0.4.4のみ記載してあります。
https://github.com/podder-ai/podder-installer/releases

リリースノートの書き方、内容に問題が無いかご確認お願いいたします。

※以下のGitHubのChangelogを参考に記述しています
https://github.com/github-changelog-generator/github-changelog-generator/blob/master/CHANGELOG.md