### PR TITLE
remove macOS from supported OS list

### DIFF
--- a/v002/getting-started/01-install-podder-ai.md
+++ b/v002/getting-started/01-install-podder-ai.md
@@ -61,7 +61,6 @@ To ensure Podder runs successfully, please accomplish following requirements.
 
 ### Requirements for Podder
 #### Supported OS
-- MacOS
 - Linux
 - Ubuntu
 


### PR DESCRIPTION
現状Mac版のPodderInstallerが存在しないため、MacOSを一旦サポートOS一覧から削除させていただきます。
また、Mac版のCircleCIの契約が完了し次第、サポートOSにMacOSを再度追加させていただきます。
細かい修正ですが、ご確認お願いいたします。

↓参考ログ
https://nexusfrontier.slack.com/archives/GB2HWFB32/p1560141521007700?thread_ts=1560136721.001600&cid=GB2HWFB32