### PR TITLE
update sidebar for getting started, and resolve markdown error

### DIFF
--- a/_sidebar.v002.md
+++ b/_sidebar.v002.md
@@ -3,6 +3,7 @@
 - Getting Started
   - [Install Podder.ai](v002/getting-started/01-install-podder-ai.md)
   - [Run Your First Application](v002/getting-started/02-run-your-first-application.md)
+  - [Deploy Your First Application](v002/getting-started/03-deploy-your-first-application.md)
 - Architecture
   - [Overview](v002/architecture/01-overview.md)
 - Guide

--- a/v002/getting-started/02-run-your-first-application.md
+++ b/v002/getting-started/02-run-your-first-application.md
@@ -45,6 +45,7 @@ Now, we will implement some logic on `podder-task`. We will write some codes in 
 
 You can modify the code inside of `execute` method in task.py. (If you would like to keep the current code, please move on to next step.)
 > DO NOT change the interface of execute method.
+
 ```
 # app.task.py
 ・・・
@@ -79,7 +80,7 @@ Next, let's build a pipeline. The pipeline design is described in the YAML file.
 version: 1.0
 tasks:                                  # Add your tasks here
   - task_name: sensor-task              # Task name
-    timeout: 30                         # Timeout setting of task 
+    timeout: 30                         # Timeout setting of task
   - task_name: podder-task
     timeout: 120
   - task_name: writer-task
@@ -120,5 +121,3 @@ $ cp podder-task/tests/files/inputs.json input/inputs.json
 You can activate your dag from the screen by switching your dag to `ON` status. After waiting for a few minutes, you can see the job is completed and the result is outputted to `output` directory.
 
 This is the end of the tutorial. You now understand how to use Podder CLI and design a pipeline on Podder.ai.
-
-


### PR DESCRIPTION
サイドバーのGettingStartedの項目に`03-deploy-your-first-application.md`がなかったので追加しました。

また、`02-run-your-first-application.md`にてコードの表記がうまく表示されていないようでしたので合わせて修正しました。

ご確認お願いします。

↓現状こんな感じで表示されていました↓
<img width="672" alt="スクリーンショット 2019-07-23 3 29 23" src="https://user-images.githubusercontent.com/8590431/61656166-1d4f0f00-acfb-11e9-832b-afd75a39d6a1.png">

↓修正後（Atomのプレビューですが）↓
<img width="586" alt="スクリーンショット 2019-07-23 3 37 33" src="https://user-images.githubusercontent.com/8590431/61656226-48396300-acfb-11e9-8bce-b1e07fa63b74.png">
